### PR TITLE
feat: add getAllDocuments function

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -558,7 +558,7 @@ func (c *Collection) queryEmbedding(ctx context.Context, queryEmbedding, negativ
 	return res, nil
 }
 
-func (c *Collection) GetAllDocuments(_ context.Context) ([]Document, error) {
+func (c *Collection) GetAllDocuments(_ context.Context, fetchDeep bool) ([]Document, error) {
 	c.documentsLock.RLock()
 	defer c.documentsLock.RUnlock()
 
@@ -566,8 +566,13 @@ func (c *Collection) GetAllDocuments(_ context.Context) ([]Document, error) {
 	for _, doc := range c.documents {
 		// Clone the document to avoid concurrent modification by reading goroutine
 		docCopy := *doc
-		docCopy.Metadata = maps.Clone(doc.Metadata)
-		docCopy.Embedding = slices.Clone(doc.Embedding)
+		if fetchDeep {
+			docCopy.Metadata = maps.Clone(doc.Metadata)
+			docCopy.Embedding = slices.Clone(doc.Embedding)
+		} else {
+			docCopy.Metadata = nil
+			docCopy.Embedding = nil
+		}
 		results = append(results, docCopy)
 	}
 	return results, nil

--- a/collection.go
+++ b/collection.go
@@ -558,7 +558,22 @@ func (c *Collection) queryEmbedding(ctx context.Context, queryEmbedding, negativ
 	return res, nil
 }
 
-func (c *Collection) GetDocumentsByMetadata(ctx context.Context, where map[string]string) ([]Document, error) {
+func (c *Collection) GetAllDocuments(_ context.Context) ([]Document, error) {
+	c.documentsLock.RLock()
+	defer c.documentsLock.RUnlock()
+
+	results := make([]Document, 0, len(c.documents))
+	for _, doc := range c.documents {
+		// Clone the document to avoid concurrent modification by reading goroutine
+		docCopy := *doc
+		docCopy.Metadata = maps.Clone(doc.Metadata)
+		docCopy.Embedding = slices.Clone(doc.Embedding)
+		results = append(results, docCopy)
+	}
+	return results, nil
+}
+
+func (c *Collection) GetDocumentsByMetadata(_ context.Context, where map[string]string) ([]Document, error) {
 	c.documentsLock.RLock()
 	defer c.documentsLock.RUnlock()
 


### PR DESCRIPTION
This PR adds a method to safely retrieve all documents from a collection, e.g. for listing them in a management view.
It supports a shallow fetch and a deep fetch mode.